### PR TITLE
Fix: Prevent unauthorized access via userId tampering

### DIFF
--- a/src/layouts/NavigationLayout.jsx
+++ b/src/layouts/NavigationLayout.jsx
@@ -162,20 +162,20 @@ function NavigationLayout() {
       });
   }, [location, modules, accesiblePaths]);
 
-  // useEffect(() => {
-  //   const allowedPaths = ["/Dashboard", "/", "/Login"];
-  //   // If the current path is in allowedPaths, skip the referrer check
-  //   if (allowedPaths.includes(location.pathname)) {
-  //     return;
-  //   }
-  //   const referrer = document.referrer;
-  //   if (!referrer) {
-  //     sessionStorage.setItem("AcharyaErpUser", null);
-  //     sessionStorage.setItem("empId", null);
-  //     sessionStorage.setItem("usertype", null);
-  //     navigate("/Login");
-  //   }
-  // }, [navigate, location.pathname]);
+  useEffect(() => {
+    const allowedPaths = ["/Dashboard", "/", "/Login"];
+    // If the current path is in allowedPaths, skip the referrer check
+    if (allowedPaths.includes(location.pathname)) {
+      return;
+    }
+    const referrer = document.referrer;
+    if (!referrer) {
+      sessionStorage.setItem("AcharyaErpUser", null);
+      sessionStorage.setItem("empId", null);
+      sessionStorage.setItem("usertype", null);
+      navigate("/Login");
+    }
+  }, [navigate, location.pathname]);
 
   const getSubMenuFromUser = () => {
     return new Promise(async (resolve, reject) => {
@@ -186,7 +186,16 @@ function NavigationLayout() {
           );
           resolve(subMenusFromUser ? subMenusFromUser.toString() : "");
         })
-        .catch((err) => reject(err));
+        .catch((err) => {
+           const statusCode = err.response?.status;
+            if (statusCode === 401) {
+                sessionStorage.setItem("AcharyaErpUser", null);
+                sessionStorage.setItem("empId", null);
+                sessionStorage.setItem("usertype", null);
+                navigate("/Login");
+            }
+              reject(err);
+        });
     });
   };
   const getRoleIds = async () => {
@@ -196,7 +205,17 @@ function NavigationLayout() {
           const roleIds = res.data.data.map((obj) => obj.role_id);
           resolve(roleIds.length > 0 ? roleIds.toString() : 0);
         })
-        .catch((err) => reject(err));
+        .catch((err) => {
+          const statusCode = err.response?.status;
+            if (statusCode === 401) {
+                sessionStorage.setItem("AcharyaErpUser", null);
+                sessionStorage.setItem("empId", null);
+                sessionStorage.setItem("usertype", null);
+                navigate("/Login");
+            }
+          
+          reject(err);
+        });
     });
   };
 


### PR DESCRIPTION
There was a security vulnerability where a user could manipulate the userId stored in sessionStorage to escalate their role or impersonate another user.

This PR introduces a one-time authorization re-check after login or page refresh:

- If the user is unauthorized, the back-end responds with an HTTP 401 Unauthorized.

- Upon receiving this response, the client automatically logs the user out and redirects them to the login page.

Github Issue Link :- [https://github.com/ankitn1311/acharya_docs/issues/52](https://github.com/ankitn1311/acharya_docs/issues/52)